### PR TITLE
Database propertiy and default entity manager

### DIFF
--- a/common/src/main/java/com/kumuluz/ee/common/config/PersistenceConfig.java
+++ b/common/src/main/java/com/kumuluz/ee/common/config/PersistenceConfig.java
@@ -10,6 +10,8 @@ public class PersistenceConfig {
 
     public static final String DB_UNIT_ENV = "DATABASE_UNIT";
 
+    public static final String DB_DRIVER_ENV = "DATABASE_DRIVER_CLASS";
+
     public static final String DB_URL_ENV = "DATABASE_URL";
 
     public static final String DB_USER_ENV = "DATABASE_USER";
@@ -20,6 +22,8 @@ public class PersistenceConfig {
 
     private String url;
 
+    private String driver;
+
     private String username;
 
     private String password;
@@ -27,6 +31,7 @@ public class PersistenceConfig {
     public PersistenceConfig() {
 
         EnvUtils.getEnv(DB_UNIT_ENV, this::setUnitName);
+        EnvUtils.getEnv(DB_DRIVER_ENV, this::setDriver);
         EnvUtils.getEnv(DB_URL_ENV, this::setUrl);
         EnvUtils.getEnv(DB_USER_ENV, this::setUsername);
         EnvUtils.getEnv(DB_PASS_ENV, this::setPassword);
@@ -63,4 +68,14 @@ public class PersistenceConfig {
     public void setPassword(String password) {
         this.password = password;
     }
+
+    public String getDriver() {
+        return driver;
+    }
+
+    public void setDriver(String driver) {
+        this.driver = driver;
+    }
+
+
 }

--- a/components/jpa/common/src/main/java/com/kumuluz/ee/jpa/common/resources/PersistenceContextResource.java
+++ b/components/jpa/common/src/main/java/com/kumuluz/ee/jpa/common/resources/PersistenceContextResource.java
@@ -10,7 +10,7 @@ import javax.persistence.EntityManager;
  */
 public class PersistenceContextResource implements ResourceReference<EntityManager> {
 
-    private EntityManager em;
+    private final EntityManager em;
 
     public PersistenceContextResource(EntityManager em) {
 

--- a/components/jpa/common/src/main/java/com/kumuluz/ee/jpa/common/resources/PersistenceContextResourceFactory.java
+++ b/components/jpa/common/src/main/java/com/kumuluz/ee/jpa/common/resources/PersistenceContextResourceFactory.java
@@ -4,7 +4,6 @@ import org.jboss.weld.injection.spi.ResourceReference;
 import org.jboss.weld.injection.spi.ResourceReferenceFactory;
 
 import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
 
 /**
  * @author Tilen Faganel
@@ -12,16 +11,15 @@ import javax.persistence.EntityManagerFactory;
  */
 public class PersistenceContextResourceFactory implements ResourceReferenceFactory<EntityManager> {
 
-    private EntityManagerFactory emf;
+    private final EntityManager em;
 
-    public PersistenceContextResourceFactory(javax.persistence.EntityManagerFactory emf) {
-
-        this.emf = emf;
+    public PersistenceContextResourceFactory(javax.persistence.EntityManager em) {
+        this.em = em;
     }
 
     @Override
     public ResourceReference<EntityManager> createResource() {
 
-        return new PersistenceContextResource(emf.createEntityManager());
+        return new PersistenceContextResource(em);
     }
 }

--- a/components/jpa/common/src/main/java/com/kumuluz/ee/jpa/common/resources/PersistenceUnitHolder.java
+++ b/components/jpa/common/src/main/java/com/kumuluz/ee/jpa/common/resources/PersistenceUnitHolder.java
@@ -33,6 +33,7 @@ public class PersistenceUnitHolder {
             config.ifPresent(c -> {
 
                 Optional.ofNullable(c.getUrl()).ifPresent(u -> properties.put("javax.persistence.jdbc.url", u));
+                Optional.ofNullable(c.getDriver()).ifPresent(d -> properties.put("javax.persistence.jdbc.driver", d));
                 Optional.ofNullable(c.getUsername()).ifPresent(u -> properties.put("javax.persistence.jdbc.user", u));
                 Optional.ofNullable(c.getPassword()).ifPresent(p -> properties.put("javax.persistence.jdbc.password", p));
             });

--- a/components/jpa/common/src/main/java/com/kumuluz/ee/jpa/common/resources/PersistenceUnitResource.java
+++ b/components/jpa/common/src/main/java/com/kumuluz/ee/jpa/common/resources/PersistenceUnitResource.java
@@ -10,7 +10,7 @@ import javax.persistence.EntityManagerFactory;
  */
 public class PersistenceUnitResource implements ResourceReference<EntityManagerFactory> {
 
-    private EntityManagerFactory emf;
+    private final EntityManagerFactory emf;
 
     public PersistenceUnitResource(EntityManagerFactory emf) {
 

--- a/components/jpa/common/src/main/java/com/kumuluz/ee/jpa/common/resources/PersistenceUnitResourceFactory.java
+++ b/components/jpa/common/src/main/java/com/kumuluz/ee/jpa/common/resources/PersistenceUnitResourceFactory.java
@@ -12,7 +12,7 @@ import javax.persistence.EntityManagerFactory;
 public class PersistenceUnitResourceFactory implements
         ResourceReferenceFactory<EntityManagerFactory> {
 
-    private EntityManagerFactory emf;
+    private final EntityManagerFactory emf;
 
     public PersistenceUnitResourceFactory(EntityManagerFactory emf) {
 

--- a/components/jpa/eclipselink/src/main/java/com/kumuluz/ee/jpa/eclipselink/JpaComponent.java
+++ b/components/jpa/eclipselink/src/main/java/com/kumuluz/ee/jpa/eclipselink/JpaComponent.java
@@ -16,7 +16,7 @@ import java.util.logging.Logger;
 @EeComponentDef(name = "EclipseLink", type = EeComponentType.JPA)
 public class JpaComponent implements Component {
 
-    private Logger log = Logger.getLogger(JpaComponent.class.getSimpleName());
+    private static final Logger log = Logger.getLogger(JpaComponent.class.getSimpleName());
 
     @Override
     public void init(KumuluzServerWrapper server, EeConfig eeConfig) {


### PR DESCRIPTION
These changes makes it posible to:
define database driver with a env property,
create defaultEntity manager and reuse same entity manager the first allows for

@PersistenceContext
EntityManager em

constructs, the latter makes sure all entitymanger instances for the same unit are the same instances

Philippe 